### PR TITLE
Fix const ptr compiler error

### DIFF
--- a/src/parser/Parser.zig
+++ b/src/parser/Parser.zig
@@ -175,7 +175,7 @@ fn parseCommandArgument(self: *Parser) Error!void {
     }
 }
 
-fn parseArg(self: *Parser, token: *Token) InternalError!void {
+fn parseArg(self: *Parser, token: *const Token) InternalError!void {
     if (token.isShortFlag()) {
         try self.parseShortArg(token);
     } else if (token.isLongFlag()) {
@@ -183,7 +183,7 @@ fn parseArg(self: *Parser, token: *Token) InternalError!void {
     }
 }
 
-fn parseShortArg(self: *Parser, token: *Token) InternalError!void {
+fn parseShortArg(self: *Parser, token: *const Token) InternalError!void {
     const flag_tuple = flagTokenToFlagTuple(token);
     var short_flag = ShortFlag.init(flag_tuple.@"0", flag_tuple.@"1");
 
@@ -221,7 +221,7 @@ fn parseShortArg(self: *Parser, token: *Token) InternalError!void {
     }
 }
 
-fn parseLongArg(self: *Parser, token: *Token) InternalError!void {
+fn parseLongArg(self: *Parser, token: *const Token) InternalError!void {
     const flag_tuple = flagTokenToFlagTuple(token);
     self.err_ctx.setProvidedArg(flag_tuple.@"0");
 
@@ -245,7 +245,7 @@ fn parseLongArg(self: *Parser, token: *Token) InternalError!void {
 // --flag, -f, -fgh                     => (flag, null), (f, null), (fgh, null)
 // --flag=value, -f=value, -fgh=value   => (flag, value), (f, value), (fgh, value)
 // --flag=, -f=, -fgh=                  => (flag, ""), (f, ""), (fgh, "")
-fn flagTokenToFlagTuple(token: *Token) FlagTuple {
+fn flagTokenToFlagTuple(token: *const Token) FlagTuple {
     var kv_iter = mem.tokenize(u8, token.value, "=");
 
     return switch (token.tag) {

--- a/src/parser/tokenizer.zig
+++ b/src/parser/tokenizer.zig
@@ -32,7 +32,7 @@ pub const Token = struct {
         return Token{ .value = value, .tag = tag };
     }
 
-    pub fn isShortFlag(self: *Token) bool {
+    pub fn isShortFlag(self: *const Token) bool {
         // zig fmt: off
         return (
             self.tag == .short_flag
@@ -45,7 +45,7 @@ pub const Token = struct {
         // zig fmt: on
     }
 
-    pub fn isLongFlag(self: *Token) bool {
+    pub fn isLongFlag(self: *const Token) bool {
         // zig fmt: off
         return (
             self.tag == .long_flag


### PR DESCRIPTION
Zig version: 0.10.0-dev.3685+dae7aeb33

When trying to integrate this library into another project I encountered an error regarding the `parse.tokenizer.Token` class. I was able to reproduce this same error when running the library's tests:

```
$ zig build test
/src/zig-arg/src/parser/Parser.zig:120:18: error: expected type '*parser.tokenizer.Token', found '*const parser.tokenizer.Token'
        if (token.isShortFlag() or token.isLongFlag()) {
            ~~~~~^~~~~~~~~~~~
/src/zig-arg/src/parser/Parser.zig:120:18: note: cast discards const qualifier
error: test...
``` 

By replacing all occurrences of `token: *Token` with `token: *const Token` in the function definitions in `src/parser/Parser.zig` and `src/parser/tokenizer.zig` this error is no longer encountered.

This is likely caused by some recent changes in the master branch of the Zig compiler.