### PR TITLE
Bump version to `v0.7.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Inspired by [clap-rs](https://github.com/clap-rs/clap) and [andrewrk/ziglang: sr
 | yazap                                                             | Zig                                      |
 | ----------------------------------------------------------------- | ---------------------------------------- |
 | main                                                              | [master](https://github.com/ziglang/zig) |
+| [`0.7.0`](https://github.com/prajwalch/yazap/releases/tag/v0.7.0) | `0.15.2`         |
 | [`0.6.3`](https://github.com/prajwalch/yazap/releases/tag/v0.6.3) | `0.14.0`         |
 | [`0.5.1`](https://github.com/prajwalch/yazap/releases/tag/v0.5.1) | `0.12.0`, `0.12.1` and  `0.13.0`         |
 | <= `0.5.0`                                                        | Not supported to any                     |

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .yazap,
-    .version = "0.6.3",
+    .version = "0.7.0",
     .fingerprint = 0xc4ff2399127e5b67,
     .paths = .{
         "build.zig",


### PR DESCRIPTION
This is the last commit that supports `0.15.2`